### PR TITLE
fix: bitbucket api limit to 1000 max in an hour

### DIFF
--- a/src/lib/azure-devops/utils/index.ts
+++ b/src/lib/azure-devops/utils/index.ts
@@ -45,7 +45,7 @@ export const getRepoCommits = async (
       },
     ),
   );
-  if(!data.ok){
+  if (!data.ok) {
     debug(`Failed to fetch page: ${url}\n ${data.body}`);
   }
   return data;
@@ -69,7 +69,7 @@ export const getReposPerProjects = async (
       },
     ),
   );
-  if(!data.ok){
+  if (!data.ok) {
     debug(`Failed to fetch page: ${url}\n ${data.body}`);
   }
   return data;
@@ -90,7 +90,7 @@ export const getProjects = async (
       },
     ),
   );
-  if(!data.ok){
+  if (!data.ok) {
     debug(`Failed to fetch page: ${url}\n ${data.body}`);
   }
   return data;

--- a/src/lib/azure-devops/utils/index.ts
+++ b/src/lib/azure-devops/utils/index.ts
@@ -45,6 +45,9 @@ export const getRepoCommits = async (
       },
     ),
   );
+  if(!data.ok){
+    debug(`Failed to fetch page: ${url}\n ${data.body}`);
+  }
   return data;
 };
 
@@ -66,6 +69,9 @@ export const getReposPerProjects = async (
       },
     ),
   );
+  if(!data.ok){
+    debug(`Failed to fetch page: ${url}\n ${data.body}`);
+  }
   return data;
 };
 
@@ -84,5 +90,8 @@ export const getProjects = async (
       },
     ),
   );
+  if(!data.ok){
+    debug(`Failed to fetch page: ${url}\n ${data.body}`);
+  }
   return data;
 };

--- a/src/lib/bitbucket-cloud/utils/index.ts
+++ b/src/lib/bitbucket-cloud/utils/index.ts
@@ -58,6 +58,9 @@ export const fetchAllPages = async (
         },
       }),
     );
+    if(!response.ok){
+      debug(`Failed to fetch page: ${url}\n ${response.body}`);
+    }
     const apiResponse = (await response.json()) as repoListApiResponse;
     values = values.concat(apiResponse.values);
     if (apiResponse.next) {

--- a/src/lib/bitbucket-cloud/utils/index.ts
+++ b/src/lib/bitbucket-cloud/utils/index.ts
@@ -58,7 +58,7 @@ export const fetchAllPages = async (
         },
       }),
     );
-    if(!response.ok){
+    if (!response.ok) {
       debug(`Failed to fetch page: ${url}\n ${response.body}`);
     }
     const apiResponse = (await response.json()) as repoListApiResponse;

--- a/src/lib/bitbucket-cloud/utils/index.ts
+++ b/src/lib/bitbucket-cloud/utils/index.ts
@@ -7,6 +7,9 @@ import base64 = require('base-64');
 const debug = debugLib('snyk:bitbucket-cloud-count');
 
 const limiter = new Bottleneck({
+  reservoir: 1000,
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
   maxConcurrent: 1,
   minTime: 500,
 });

--- a/src/lib/bitbucket-server/utils/index.ts
+++ b/src/lib/bitbucket-server/utils/index.ts
@@ -54,6 +54,9 @@ export const fetchAllPages = async (
         headers: { Authorization: 'Bearer ' + token },
       }),
     );
+    if(!response.ok){
+      debug(`Failed to fetch page: ${url}\n ${response.body}`);
+    }
     const apiResponse = (await response.json()) as repoListApiResponse;
     values = values.concat(apiResponse.values);
     isLastPage = apiResponse.isLastPage;

--- a/src/lib/bitbucket-server/utils/index.ts
+++ b/src/lib/bitbucket-server/utils/index.ts
@@ -54,7 +54,7 @@ export const fetchAllPages = async (
         headers: { Authorization: 'Bearer ' + token },
       }),
     );
-    if(!response.ok){
+    if (!response.ok) {
       debug(`Failed to fetch page: ${url}\n ${response.body}`);
     }
     const apiResponse = (await response.json()) as repoListApiResponse;

--- a/src/lib/bitbucket-server/utils/index.ts
+++ b/src/lib/bitbucket-server/utils/index.ts
@@ -6,6 +6,9 @@ import Bottleneck from 'bottleneck';
 const debug = debugLib('snyk:bitbucket-server-count');
 
 const limiter = new Bottleneck({
+  reservoir: 1000, // initial value
+  reservoirRefreshAmount: 1000,
+  reservoirRefreshInterval: 3600 * 1000,
   maxConcurrent: 1,
   minTime: 500,
 });


### PR DESCRIPTION
BB has an API rate limit of 1000 max/hour per user : https://support.atlassian.com/bitbucket-cloud/docs/api-request-limits/
This fix addresses that issue by limiting the api calls through Bottleneck for a max of 1000/hour.