### PR TITLE
fix: apply fix from snyk to vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,9 +1072,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.177",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
-      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
+      "version": "4.14.178",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
+      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
     },
     "@types/ms": {
       "version": "0.7.31",
@@ -1343,9 +1343,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2293,9 +2293,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -4324,9 +4324,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-          "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+          "version": "14.18.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
+          "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A=="
         },
         "typescript": {
           "version": "3.9.10",
@@ -4347,14 +4347,14 @@
       }
     },
     "snyk-request-manager": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/snyk-request-manager/-/snyk-request-manager-1.4.2.tgz",
-      "integrity": "sha512-vCVQ4tkbuAQu5a0H1ArfkvOF6cQwwEOYvMJzErsu9rpj+TnRXtp2+rGq2hOwm61MBHA5LSVAdlJPok13xh+/1A==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/snyk-request-manager/-/snyk-request-manager-1.4.3.tgz",
+      "integrity": "sha512-ZSI392zW10pFg7G42bJAmhvm5Ub2uMiM6saC3hzOrIsE9wWPF0AyAYXgJXquJJQeMEPNBdj0xQKkkMF97ffAvQ==",
       "requires": {
         "@snyk/configstore": "^3.2.0-rc1",
         "@types/debug": "^4.1.7",
         "@types/uuid": "^7.0.3",
-        "axios": "^0.21.1",
+        "axios": "0.21.4",
         "chalk": "^4.0.0",
         "debug": "^4.1.1",
         "leaky-bucket-queue": "0.0.2",


### PR DESCRIPTION
```
Issues with no direct upgrade or patch:
Information Exposure [Medium Severity][https://snyk.io/vuln/SNYK-JS-FOLLOWREDIRECTS-2332181] in follow-redirects@1.14.5
introduced by snyk-api-ts-client@1.8.1 > axios@0.24.0 > follow-redirects@1.14.5 and 1 other path(s)
This issue was fixed in versions: 1.14.7
```