### PR TITLE
feat: remove skipSnykMonitored option for some SCMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm i -g snyk-scm-contributors-count
 ```
 or use corresponding binaries in the [release page](https://github.com/snyk-tech-services/snyk-scm-contributors-count/releases)
 
+## Link to full documetation
+[Snyk Docs](https://docs.snyk.io/features/other-tools/snyk-scm-contributors-count-cli-tool)
 
 ## Usage
 

--- a/docs/azure-example.md
+++ b/docs/azure-example.md
@@ -17,7 +17,7 @@ Available options:
 
 ### Before running the command:
 1. Export SNYK_TOKEN (if you want to get the contributors ONLY for repos that are already monitored by Snyk) =>
-    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists.
+    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists, make sure that your token has Group level access or use a service account's token that has Group level access, to learn more on how to create a service account, refer to this [guide](https://docs.snyk.io/features/integrations/managing-integrations/service-accounts#how-to-set-up-a-service-account).
     - Copy the token value
     - Export the token in your enviroment: 
     ```

--- a/docs/bitbucket-cloud-example.md
+++ b/docs/bitbucket-cloud-example.md
@@ -16,13 +16,13 @@ Available options:
 
 Before running the command:
 1. Export SNYK_TOKEN (if you want to get the contributors ONLY for repos that are already monitored by Snyk) =>
-    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists.
+    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists, make sure that your token has Group level access or  use a service account's token that has Group level access, to learn more on how to create a service account, refer to this [guide](https://docs.snyk.io/features/integrations/managing-integrations/service-accounts#how-to-set-up-a-service-account).
     - Copy the token value
     - Export the token in your enviroment: 
     ```
     export SNYK_TOKEN=<YOUR-SNYK-TOKEN>
     ```
-2. Get your Bitbucket-Cloud user and password =>
+2. Get your Bitbucket-Cloud user and App password =>
     - Make sure that your credentials have access to the repos that you want to get the contributor count for
 
 ### Running the command

--- a/docs/bitbucket-server-example.md
+++ b/docs/bitbucket-server-example.md
@@ -16,7 +16,7 @@ Available options:
 
 Before running the command:
 1. Export SNYK_TOKEN (if you want to get the contributors ONLY for repos that are already monitored by Snyk) =>
-    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists.
+    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists, make sure that your token has Group level access or use a service account's token that has Group level access, to learn more on how to create a service account, refer to this [guide](https://docs.snyk.io/features/integrations/managing-integrations/service-accounts#how-to-set-up-a-service-account).
     - Copy the token value
     - Export the token in your enviroment: 
     ```

--- a/docs/github-enterprise-example.md
+++ b/docs/github-enterprise-example.md
@@ -13,20 +13,10 @@ Available options:
                             rather than fetching only the orgs your authorized to operate in.
   --exclusionFilePath       [Optional] Exclusion list filepath
   --json                    [Optional] JSON output, required when using the "consolidateResults" command
-  --skipSnykMonitoredRepos  [Optional] Skip Snyk monitored repos and count contributors for all repos
-  --importConfDir           [Optional] Generate an import file with the unmonitored repos: A path to a valid folder for the generated import files
-  --importFileRepoType      [Optional] To be used with the importConfDir flag: Specify the type of repos to be added to the import file. Options: all/private/public. Default: all
 ```
 
-Before running the command:
-1. Export SNYK_TOKEN (if you want to get the contributors ONLY for repos that are already monitored by Snyk) =>
-    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists.
-    - Copy the token value
-    - Export the token in your enviroment: 
-    ```
-    export SNYK_TOKEN=<YOUR-SNYK-TOKEN>
-    ```
-2. Get your Github Enterprise token or create a new one with this [guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) =>
+### Before running the command:
+Get your Github Enterprise token or create a new one with this [guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) =>
     - Make sure that your token has access to the repos that you want to get the contributors count for
 
 ### Running the command
@@ -52,10 +42,6 @@ snyk-scm-contributors-count github-enterprise --token TOKEN --url HOST_URL --org
 ```
 
 #### Options:
-- I want to get all the commits from Github Enterprise regardless of the repos that are already monitored by Snyk (You might have repo in Github Enterprise that are not monitored in Snyk, using this flag will skip checking for Snyk monitored repos and will go directly to Github Enterprise to fetch tha commits) => add the `--skipSnykMonitoredRepos` flag to the command:
-```
-snyk-scm-contributors-count github-enterprise --token TOKEN --url HOST_URL --skipSnykMonitoredRepos
-```
 - I want tp map ALL the orgs in Github Enterprise and not only the ones I have operate rights to => add the `--fetchAllOrgs` flag to the command:
 ```
 snyk-scm-contributors-count github-enterprise --token TOKEN --url HOST_URL --fetchAllOrgs
@@ -69,11 +55,6 @@ snyk-scm-contributors-count github-enterprise --token TOKEN --url HOST_URL --org
 - I want the output to be in json format => add the `--json` flag to the command:
 ```
 snyk-scm-contributors-count github-enterprise --token TOKEN --url HOST_URL --json
-```
-
-- I want the tool to create an import file for me with my unmonitored repos => add the `--importConfDir` flag to the command with a valid (writable) path to a folder in which the import files will be stored and add the `--importFileRepoType` flag (optional) with the repo types to add to the file (all/private/public, defaults to all). (**Note that these flags can not be set with the `--repo` flag**):
-```
-snyk-scm-contributors-count github-enterprise --token TOKEN --url HOST_URL --importConfDir ValidPathToWritableFolder --importFileRepoType private/public/all
 ```
 
 - I want to run in debug mode for verbose output => add `DEBUG=snyk*` to the beginning of the command:

--- a/docs/github-example.md
+++ b/docs/github-example.md
@@ -9,20 +9,10 @@ Available options:
   --repo                    [Optional] Specific repo to count only for
   --exclusionFilePath       [Optional] Exclusion list filepath
   --json                    [Optional] JSON output, required when using the "consolidateResults" command
-  --skipSnykMonitoredRepos  [Optional] Skip Snyk monitored repos and count contributors for all repos
-  --importConfDir           [Optional] Generate an import file with the unmonitored repos: A path to a valid folder for the generated import files
-  --importFileRepoType      [Optional] To be used with the importConfDir flag: Specify the type of repos to be added to the import file. Options: all/private/public. Default: all
 ```
 
-Before running the command:
-1. Export SNYK_TOKEN (if you want to get the contributors ONLY for repos that are already monitored by Snyk) =>
-    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists.
-    - Copy the token value
-    - Export the token in your enviroment: 
-    ```
-    export SNYK_TOKEN=<YOUR-SNYK-TOKEN>
-    ```
-2. Get your Github token or create a new one with this [guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) =>
+### Before running the command:
+Get your Github token or create a new one with this [guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) =>
     - Make sure that your token has access to the repos that you want to get the contributors count for
 
 ### Running the command
@@ -48,10 +38,6 @@ snyk-scm-contributors-count github --token TOKEN --orgs ORG --repo REPO
 ```
 
 #### Options:
-- I want to get all the commits from Github regardless of the repos that are already monitored by Snyk (You might have repo in Github that are not monitored in Snyk, using this flag will skip checking for Snyk monitored repos and will go directly to Github to fetch tha commits) => add the `--skipSnykMonitoredRepos` flag to the command:
-```
-snyk-scm-contributors-count github --token TOKEN --skipSnykMonitoredRepos
-```
 - I want to exclude some contributors from being counted in the commits => add an exclusion file with the emails to ignore(seperated by commas) and apply the `--exclusionFilePath` with the path to that file to the command:
 ```
 snyk-scm-contributors-count github --token TOKEN --orgs ORG_ONE,ORG_TWO --exclusionFilePath PATH_TO_FILE
@@ -60,11 +46,6 @@ snyk-scm-contributors-count github --token TOKEN --orgs ORG_ONE,ORG_TWO --exclus
 - I want the output to be in json format => add the `--json` flag to the command:
 ```
 snyk-scm-contributors-count github --token TOKEN --json
-```
-
-- I want the tool to create an import file for me with my unmonitored repos => add the `--importConfDir` flag to the command with a valid (writable) path to a folder in which the import files will be stored and add the `--importFileRepoType` flag (optional) with the repo types to add to the file (all/private/public, defaults to all). (**Note that these flags can not be set with the `--repo` flag**):
-```
-snyk-scm-contributors-count github --token TOKEN --importConfDir ValidPathToWritableFolder --importFileRepoType private/public/all
 ```
 
 - I want to run in debug mode for verbose output => add `DEBUG=snyk*` to the beginning of the command:

--- a/docs/gitlab-example.md
+++ b/docs/gitlab-example.md
@@ -11,20 +11,10 @@ Available options:
   --project                 [Optional] Your Gitlab project path with namespace to count contributors for
   --exclusionFilePath       [Optional] Exclusion list filepath
   --json                    [Optional] JSON output, requiered when using the "consolidateResults" command
-  --skipSnykMonitoredRepos  [Optional] Skip Snyk monitored projects and count contributors for all projects
-  --importConfDir           [Optional] Generate an import file with the unmonitored projects: A path to a valid folder for the generated import files
-  --importFileRepoType      [Optional] To be used with the importConfDir flag: Specify the type of repos to be added to the import file. Options: all/private/public. Default: all
 ```
 
-Before running the command:
-1. Export SNYK_TOKEN (if you want to get the contributors ONLY for projects that are already monitored by Snyk) => 
-    - Go to [Snyk-account](https://app.snyk.io/account) and create a token if not already exists.
-    - Copy the token value
-    - Export the token in your enviroment: 
-    ```
-    export SNYK_TOKEN=<YOUR-SNYK-TOKEN>
-    ```
-2. Get your Gitlab token or create a new one with this [guide](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) =>
+### Before running the command:
+Get your Gitlab token or create a new one with this [guide](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) =>
     - Make sure that your token has access to the projects that you want to get the contributors count for
 
 ### Running the command
@@ -50,11 +40,6 @@ snyk-scm-contributors-count gitlab --token TOKEN --groups Group --project PROJEC
 ```
 
 #### Options:
-- I want to get all the commits from Gitlab regardless of the projects that are already monitored by Snyk (You might have projects in Gitlab that are not monitored in Snyk, using this flag will skip checking for Snyk monitored projects and will go directly to Gitlab to fetch tha commits) => add the `--skipSnykMonitoredRepos` flag to the command:
-```
-snyk-scm-contributors-count gitlab --token TOKEN --url URL --skipSnykMonitoredRepos
-```
-
 - I want to exclude some contributors from being counted in the commits => add an exclusion file with the emails to ignore(seperated by commas) and apply the `--exclusionFilePath` with the path to that file to the command:
 ```
 snyk-scm-contributors-count gitlab --token TOKEN --projectKeys Path1/Namespace1 --exclusionFilePath PATH_TO_FILE
@@ -63,11 +48,6 @@ snyk-scm-contributors-count gitlab --token TOKEN --projectKeys Path1/Namespace1 
 - I want the output to be in json format => add the `--json` flag to the command:
 ```
 snyk-scm-contributors-count gitlab --token TOKEN --json
-```
-
-- I want the tool to create an import file for me with my unmonitored projects => add the `--importConfDir` flag to the command with a valid (writable) path to a folder in which the import files will be stored and add the `--importFileRepoType` flag (optional) with the projects types to add to the file (all/private/public, defaults to all). (**Note that these flags can not be set with the `--project` flag**):
-```
-snyk-scm-contributors-count gitlab --token TOKEN --importConfDir ValidPathToWritableFolder --importFileRepoType private/public/all
 ```
 
 - I want to run in debug mode for verbose output => add `DEBUG=snyk*` to the beginning of the command:

--- a/src/cmds/azure-devops.ts
+++ b/src/cmds/azure-devops.ts
@@ -68,8 +68,8 @@ class AzureDevops extends SCMHandlerClass {
   }
 
   async fetchSCMContributors(
-    SnykMonitoredRepos: string[],
     integrations: Integration[],
+    SnykMonitoredRepos: string[],
     importConfDir: string,
     importFileRepoType: string,
   ): Promise<ContributorMap> {
@@ -151,10 +151,10 @@ export async function handler(argv: {
   await azureDevopsTask.scmContributorCount(
     azureDefaultUrls,
     SourceType['azure-repos'],
+    argv.exclusionFilePath,
+    argv.json,
     argv.skipSnykMonitoredRepos,
     argv.importConfDir,
     argv.importFileRepoType,
-    argv.exclusionFilePath,
-    argv.json,
   );
 }

--- a/src/cmds/bitbucket-cloud.ts
+++ b/src/cmds/bitbucket-cloud.ts
@@ -68,8 +68,8 @@ class BitbucketCloud extends SCMHandlerClass {
   }
 
   async fetchSCMContributors(
-    SnykMonitoredRepos: string[],
     integrations: Integration[],
+    SnykMonitoredRepos: string[],
     importConfDir: string,
     importFileRepoType: string,
   ): Promise<ContributorMap> {
@@ -151,10 +151,10 @@ export async function handler(argv: {
   await bitbucketCloudTask.scmContributorCount(
     bitbucketCloudDefaultUrl,
     SourceType['bitbucket-cloud'],
+    argv.exclusionFilePath,
+    argv.json,
     argv.skipSnykMonitoredRepos,
     argv.importConfDir,
     argv.importFileRepoType,
-    argv.exclusionFilePath,
-    argv.json,
   );
 }

--- a/src/cmds/bitbucket-server.ts
+++ b/src/cmds/bitbucket-server.ts
@@ -64,8 +64,8 @@ class BitbucketServer extends SCMHandlerClass {
   }
 
   async fetchSCMContributors(
-    SnykMonitoredRepos: string[],
     integrations: Integration[],
+    SnykMonitoredRepos: string[],
     importConfDir: string,
     importFileRepoType: string,
   ): Promise<ContributorMap> {
@@ -148,10 +148,10 @@ export async function handler(argv: {
   await bitbucketServerTask.scmContributorCount(
     argv.url,
     SourceType['bitbucket-server'],
+    argv.exclusionFilePath,
+    argv.json,
     argv.skipSnykMonitoredRepos,
     argv.importConfDir,
     argv.importFileRepoType,
-    argv.exclusionFilePath,
-    argv.json,
   );
 }

--- a/src/cmds/gitlab.ts
+++ b/src/cmds/gitlab.ts
@@ -3,8 +3,6 @@ import { GitlabTarget, ContributorMap, Integration } from '../lib/types';
 import { SCMHandlerClass } from '../lib/common/SCMHandler';
 import { SourceType } from '../lib/snyk';
 import { fetchGitlabContributors } from '../lib/gitlab/gitlab-contributors';
-import { access } from 'fs/promises';
-import { constants } from 'fs';
 
 const debug = debugLib('snyk:gitlab-count');
 const d = new Date();
@@ -43,19 +41,6 @@ export const builder = {
     required: false,
     desc: '[Optional] JSON output',
   },
-  skipSnykMonitoredRepos: {
-    required: false,
-    desc: '[Optional] Skip Snyk monitored projects and count contributors for all projects',
-  },
-  importConfDir: {
-    required: false,
-    desc: '[Optional] A path to a valid folder for the generated import files',
-  },
-  importFileRepoType: {
-    required: false,
-    default: '',
-    desc: '[Optional] Specify the type of repos to be added to the import file. Options: all/private/public. Default: all',
-  },
 };
 
 class Gitlab extends SCMHandlerClass {
@@ -66,10 +51,7 @@ class Gitlab extends SCMHandlerClass {
   }
 
   async fetchSCMContributors(
-    SnykMonitoredRepos: string[],
     integrations: Integration[],
-    importConfDir: string,
-    importFileRepoType: string,
   ): Promise<ContributorMap> {
     let contributors: ContributorMap = new Map();
     try {
@@ -81,10 +63,6 @@ class Gitlab extends SCMHandlerClass {
       );
       contributors = await fetchGitlabContributors(
         this.gitlabConnInfo,
-        SnykMonitoredRepos,
-        integrations,
-        importConfDir,
-        importFileRepoType,
         threeMonthsDate,
       );
     } catch (e) {
@@ -102,41 +80,17 @@ export async function handler(argv: {
   project: string;
   exclusionFilePath: string;
   json: boolean;
-  skipSnykMonitoredRepos: boolean;
-  importConfDir: string;
-  importFileRepoType: string;
 }): Promise<void> {
   if (process.env.DEBUG) {
     debug('DEBUG MODE ENABLED \n');
     debug(
       'ℹ️  Options: ' +
         JSON.stringify(
-          `Url: ${argv.url}, Groups: ${argv.groups}, Project: ${argv.project}, skipSnykMonitoredRepos: ${argv.skipSnykMonitoredRepos}, ExclusionFile: ${argv.exclusionFilePath}, ImportConfDir: ${argv.importConfDir}, ImportFileRepoType: ${argv.importFileRepoType}`,
+          `Url: ${argv.url}, Groups: ${argv.groups}, Project: ${argv.project}, ExclusionFile: ${argv.exclusionFilePath}`,
         ),
     );
   }
-  if (argv.importConfDir) {
-    try {
-      await access(argv.importConfDir, constants.W_OK);
-    } catch {
-      console.error(
-        `Cannot access ${argv.importConfDir} for writing, please restart and provide a valid path`,
-      );
-      process.exit(1);
-    }
-  }
-  if (argv.importConfDir && argv.project) {
-    console.log(
-      'Triggering the importConfDir flag cannot be done for a single repo. Please remove the flag from the command or run without the project flag',
-    );
-    process.exit(1);
-  }
-  if (argv.importFileRepoType != '' && !argv.importConfDir) {
-    console.log(
-      'The importFileRepoType flag was set without the importConfDir flag, please restart and pass the importConfDir or remove the importFileRepoType flag',
-    );
-    process.exit(1);
-  }
+
   const scmTarget: GitlabTarget = {
     token: argv.token,
     url: argv.url.endsWith('/') ? argv.url.slice(0, -1) : argv.url,
@@ -149,9 +103,6 @@ export async function handler(argv: {
   await gitlabTask.scmContributorCount(
     argv.url,
     SourceType['gitlab'],
-    argv.skipSnykMonitoredRepos,
-    argv.importConfDir,
-    argv.importFileRepoType,
     argv.exclusionFilePath,
     argv.json,
   );

--- a/test/lib/github-enterprise/github-enterprise-contributors.test.ts
+++ b/test/lib/github-enterprise/github-enterprise-contributors.test.ts
@@ -105,10 +105,6 @@ describe('Testing github-enterprise interaction', () => {
     const contributorsMap: ContributorMap =
       await ghe.fetchGithubEnterpriseContributors(
         gheInfo,
-        [],
-        [],
-        '',
-        '',
         '2021-06-01T00:00:01Z',
       );
 

--- a/test/lib/github/github-contributors.test.ts
+++ b/test/lib/github/github-contributors.test.ts
@@ -86,14 +86,7 @@ describe('Testing github interaction', () => {
       repo: 'module',
     };
     const contributorsMap: ContributorMap =
-      await github.fetchGithubContributors(
-        githubInfo,
-        [],
-        [],
-        '',
-        '',
-        '2021-06-01T00:00:01Z',
-      );
+      await github.fetchGithubContributors(githubInfo, '2021-06-01T00:00:01Z');
 
     const expectedMap = new Map<string, Contributor>();
     expectedMap.set('Tech Services', {

--- a/test/lib/gitlab/gitlab-contributors.test.ts
+++ b/test/lib/gitlab/gitlab-contributors.test.ts
@@ -84,14 +84,7 @@ describe('Testing gitlab interaction', () => {
       project: 'TechServices/testProject',
     };
     const contributorsMap: ContributorMap =
-      await gitlab.fetchGitlabContributors(
-        gitlabInfo,
-        [],
-        [],
-        '',
-        '',
-        '2021-06-01T00:00:01Z',
-      );
+      await gitlab.fetchGitlabContributors(gitlabInfo, '2021-06-01T00:00:01Z');
 
     const expectedMap = new Map<string, Contributor>();
     expectedMap.set('Tech Services', {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Removes scanning Snyk repos option for GH, GHE and Gitlab

### More information

- [Jira ticket TECHSERV-1815](https://snyksec.atlassian.net/browse/TECHSERV-1815)
- [Link to documentation](https://github.com/snyk-tech-services/snyk-scm-contributors-count/wiki/)