### PR TITLE
feat: adding higher pagelen to bibucket cloud calls

### DIFF
--- a/src/lib/bitbucket-cloud/bitbucket-cloud-contributors.ts
+++ b/src/lib/bitbucket-cloud/bitbucket-cloud-contributors.ts
@@ -109,7 +109,7 @@ export const fetchBitbucketCloudContributorsForRepo = async (
   repo: Repo,
   contributorsMap: ContributorMap,
 ): Promise<void> => {
-  const fullUrl = `${bitbucketCloudDefaultUrl}/api/2.0/repositories/${repo.workspace.uuid}/${repo.slug}/commits`;
+  const fullUrl = `${bitbucketCloudDefaultUrl}/api/2.0/repositories/${repo.workspace.uuid}/${repo.slug}/commits?pagelen=100`;
   try {
     debug(
       `Fetching single repo contributor from bitbucket-cloud. Worspace ${repo.workspace.uuid} - Repo ${repo.slug}\n`,
@@ -244,7 +244,7 @@ export const fetchBitbucketCloudReposForWorkspaces = async (
       ]
     : bitbucketCloudInfo.workspaces.map(
         (workspace) =>
-          `${bitbucketCloudDefaultUrl}/api/2.0/repositories/${workspace}`,
+          `${bitbucketCloudDefaultUrl}/api/2.0/repositories/${workspace}?pagelen=100`,
       );
   try {
     for (let i = 0; i < fullUrlSet.length; i++) {

--- a/test/lib/bitbucket-cloud/bitbucket-cloud-contributors.test.ts
+++ b/test/lib/bitbucket-cloud/bitbucket-cloud-contributors.test.ts
@@ -21,11 +21,11 @@ beforeEach(() => {
     .reply(200, (uri) => {
       console.log(uri);
       switch (uri) {
-        case '/api/2.0/repositories/snyk-test':
+        case '/api/2.0/repositories/snyk-test?pagelen=100':
           return fs.readFileSync(fixturesFolderPath + 'snyk-test-repos.json');
-        case '/api/2.0/repositories/69a57492-684f-4c09-b8ba-17e03bd5e04a/testRepo1/commits':
+        case '/api/2.0/repositories/69a57492-684f-4c09-b8ba-17e03bd5e04a/testRepo1/commits?pagelen=100':
           return fs.readFileSync(fixturesFolderPath + 'testRepo1-commits.json');
-        case '/api/2.0/repositories/snyk-main':
+        case '/api/2.0/repositories/snyk-main?pagelen=100':
           return fs.readFileSync(fixturesFolderPath + 'repos-page1.json');
         case '/api/2.0/repositories/snyk-main/page2':
           return fs.readFileSync(fixturesFolderPath + 'repos-page2.json');


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adding the pagelen var to the Bitbucket cloud calls to lessen the number of calls