### PR TITLE
docs: mark repo as in maintenance only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Snyk SCM Contributors counting
+[![Not Maintained](https://img.shields.io/badge/Maintenance%20Level-Not%20Maintained-yellow.svg)](https://gist.github.com/cheerfulstoic/d107229326a01ff0f333a1d3476e068d)
+
+**This repository is not in active developemnt and critical bug fixes only will be considered.**
 
 This tool is used to count contributors with commits in the last 90 days in repositories matching the following criteria:
 1. Repo name XYZ (single repo mode if available for SCM command - see help)


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
This repo is in maintenance only mode