### PR TITLE
fix: be more inclusive in cli monitored projects inclusion

### DIFF
--- a/src/lib/snyk/index.ts
+++ b/src/lib/snyk/index.ts
@@ -134,11 +134,13 @@ export const retrieveMonitoredReposBySourceType = async (
         let targets = targetsResponse.data.data as TargetType[];
 
         if (SourceType[sourceType] === 'cli' && scmHostname) {
-          targets = targets.filter(
-            (target: TargetType) =>
-              target.attributes.remoteUrl &&
-              target.attributes.remoteUrl.includes(scmHostname),
-          );
+          targets = targets.filter((target: TargetType) => {
+            return (
+              (target.attributes.remoteUrl &&
+                target.attributes.remoteUrl.includes(scmHostname)) ||
+              !target.attributes.remoteUrl?.startsWith('http')
+            );
+          });
         }
         const targetDisplayNames = targets.map(
           (target) => target.attributes.displayName,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Relaxes a bit the inclusion of CLI monitored projects to include cases for which the remoteUrl doesn't contain a uri but rather a target name.