### PR TITLE
fix: compare contrib emails without case sensitivity

### DIFF
--- a/src/lib/consolidateResults/consolidate.ts
+++ b/src/lib/consolidateResults/consolidate.ts
@@ -33,14 +33,15 @@ export const consolidateResults = async (
         if (
           consolidatedContriburosList.find(
             (item) =>
-              item.contributor.email == isContributorInArray.contributor.email,
+              item.contributor.email.toLowerCase() ==
+              isContributorInArray.contributor.email.toLowerCase(),
           )
         ) {
           consolidatedContriburosList[
             consolidatedContriburosList.findIndex(
               (item) =>
-                item.contributor.email ==
-                isContributorInArray.contributor.email,
+                item.contributor.email.toLowerCase() ==
+                isContributorInArray.contributor.email.toLowerCase(),
             )
           ] = isContributorInArray;
         } else {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Avoids counting contributors several types due to email address in different cases.