### PR TITLE
Fix/move bitbucket cloud auth to api token

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,35 +5,40 @@ ignore:
   SNYK-JS-SEMVER-3247795:
     - '*': {}
     - reason: No upgrade path
-    - expires: '2023-11-19T13:54:01.451Z'
+    - expires: '2027-01-21T12:00:00.000Z'
   SNYK-JS-AXIOS-6032459:
     - '*':
-        reason: Not applicable in CLI tool.
-        expires: 2025-09-19T11:46:32.420Z
-        created: 2025-08-20T11:46:32.423Z
+        reason: ignoring as not applicable in a cli tool
+        expires: 2027-01-21T12:00:00.000Z
+        created: 2026-01-21T10:28:18.946Z
   SNYK-JS-AXIOS-6144788:
     - '*':
         reason: Not applicable to this lib and tool
-        expires: 2024-12-10T00:00:00.000Z
+        expires: 2027-01-21T12:00:00.000Z
         created: 2024-05-07T10:11:34.424Z
   SNYK-JS-AXIOS-6124857:
     - '*':
         reason: No reDOS applicable in CLI tool.
-        expires: 2025-09-19T11:45:52.651Z
+        expires: 2027-01-21T12:00:00.000Z
         created: 2025-08-20T11:45:52.654Z
   SNYK-JS-AXIOS-9403194:
     - '*':
         reason: No server side forgery applicable in CLI tool.
-        expires: 2025-09-19T11:45:15.643Z
+        expires: 2027-01-21T12:00:00.000Z
         created: 2025-08-20T11:45:15.647Z
   SNYK-JS-AXIOS-9292519:
     - '*':
         reason: No server side forgery applicable in CLI tool.
-        expires: 2025-09-19T11:45:31.385Z
+        expires: 2027-01-21T12:00:00.000Z
         created: 2025-08-20T11:45:31.393Z
   SNYK-JS-FORMDATA-10841150:
     - '*':
         reason: 'Not applicable in CLI tool, not using forms at all.'
-        expires: 2025-09-19T11:46:10.852Z
+        expires: 2027-01-21T12:00:00.000Z
         created: 2025-08-20T11:46:10.856Z
+  SNYK-JS-AXIOS-12613773:
+    - '*':
+        reason: 'Not applicable in CLI tool, resource allocation not a concern.'
+        expires: 2027-01-21T12:00:00.000Z
+        created: 2026-01-21T12:00:00.000Z
 patch: {}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 **This repository is in maintenance mode, no new features are being developed. Bug & security fixes will continue to be delivered. Open source contributions are welcome for small features & fixes (no breaking changes)**
 
+### Important note - January 2026
+
+Following bitbucket cloud app password deprecation, this tool will no longer work with app passwords and will require an API Token instead.
+
+### What this does
+
 This tool is used to count contributors with commits in the last 90 days in repositories matching the following criteria:
 
 1. Repo name XYZ (single repo mode if available for SCM command - see help)
@@ -57,7 +63,7 @@ snyk-scm-contributors-count bitbucket-server --token BITBUCKET-TOKEN --url http:
 ```
 
 ```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --workspaces Workspace1,Workspace2 --repo Repo --skipSnykMonitoredRepos
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --workspaces Workspace1,Workspace2 --repo Repo --skipSnykMonitoredRepos
 ```
 
 ```

--- a/docs/bitbucket-cloud-example.md
+++ b/docs/bitbucket-cloud-example.md
@@ -1,10 +1,14 @@
+## Important note - January 2026
+
+Following bitbucket cloud app password deprecation, this tool will no longer work with app passwords and will require an API Token instead.
+
 ## Bitbucket-Cloud
 Available options:
 ```
   --version                 Show version number                        [boolean]
   --help                    Show help                                  [boolean]
   --user                    Bitbucket cloud username                   [required]
-  --password                Bitbucket cloud password                   [required]
+  --password                Bitbucket cloud APITOKEN                   [required]
   --workspaces              [Optional] Bitbucket cloud workspace name/uuid to count contributors for
   --repo                    [Optional] Specific repo to count only for
   --exclusionFilePath       [Optional] Exclusion list filepath
@@ -22,7 +26,7 @@ Before running the command:
     ```
     export SNYK_TOKEN=<YOUR-SNYK-TOKEN>
     ```
-2. Get your Bitbucket-Cloud user and App password =>
+2. Get your Bitbucket-Cloud user and APITOKEN =>
     - Make sure that your credentials have access to the repos that you want to get the contributor count for
 
 ### Running the command
@@ -30,43 +34,43 @@ Before running the command:
 Consider the following levels of usage and options:
 
 #### Usage levels:
-- I want to get commits for all workspaces and their repos in Bitbucket-Cloud => Only provide the Bitbucket-Cloud user and password: 
+- I want to get commits for all workspaces and their repos in Bitbucket-Cloud => Only provide the Bitbucket-Cloud user and APITOKEN: 
 ```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD
-```
-
-- I want to get commits for some workspaces and their repos in Bitbucket-Cloud => Provide the Bitbucket-Cloud user, Bitbucket-Cloud password and the workspace/s seperated by a comma:
-```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --workspaces Workspace1,Workspace2...
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN
 ```
 
-- I want to get commits for a specific repo in Bitbucket-Cloud => Provide your Bitbucket-Cloud user, Bitbucket-Cloud password, a workspace and a repo name:
+- I want to get commits for some workspaces and their repos in Bitbucket-Cloud => Provide the Bitbucket-Cloud user, Bitbucket-Cloud APITOKEN and the workspace/s seperated by a comma:
 ```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --workspaces Workspace1 --repo Repo1
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --workspaces Workspace1,Workspace2...
+```
+
+- I want to get commits for a specific repo in Bitbucket-Cloud => Provide your Bitbucket-Cloud user, Bitbucket-Cloud APITOKEN, a workspace and a repo name:
+```
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --workspaces Workspace1 --repo Repo1
 ```
 
 #### Options:
 - I want to get all the commits from Bitbucket-Cloud regardless of the repos that are already monitored by Snyk (You might have repos in Bitbucket-Cloud that are not monitored in Snyk, using this flag will skip checking for Snyk monitored repos and will go directly to Bitbucket-Cloud to fetch tha commits) => add the `--skipSnykMonitoredRepos` flag to the command:
 ```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --skipSnykMonitoredRepos
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --skipSnykMonitoredRepos
 ```
 
 - I want to exclude some contributors from being counted in the commits => add an exclusion file with the emails to ignore(seperated by commas) and apply the `--exclusionFilePath` with the path to that file to the command:
 ```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --workspaces Workspace1,Workspace2 --exclusionFilePath PATH_TO_FILE
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --workspaces Workspace1,Workspace2 --exclusionFilePath PATH_TO_FILE
 ```
 
 - I want the output to be in json format => add the `--json` flag to the command:
 ```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --workspaces Workspace1 --repo Repo1 --json
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --workspaces Workspace1 --repo Repo1 --json
 ```
 
 - I want the tool to create an import file for me with my unmonitored repos => add the `--importConfDir` flag to the command with a valid (writable) path to a folder in which the import files will be stored and add the `--importFileRepoType` flag (optional) with the repo types to add to the file (all/private/public, defaults to all). (**Note that these flags can not be set with the `--repo` flag**):
 ```
-snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --importConfDir ValidPathToFolder --importFileRepoType private/public/all
+snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --importConfDir ValidPathToFolder --importFileRepoType private/public/all
 ```
 
 - I want to run in debug mode for verbose output => add `DEBUG=snyk*` to the beginning of the command:
 ```
-DEBUG=snyk* snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password PASSWORD --workspaces Workspace1 --repo Repo1 --exclusionFilePath PATH_TO_FILE --skipSnykMonitoredRepos --json
+DEBUG=snyk* snyk-scm-contributors-count bitbucket-cloud --user USERNAME --password APITOKEN --workspaces Workspace1 --repo Repo1 --exclusionFilePath PATH_TO_FILE --skipSnykMonitoredRepos --json
 ```

--- a/src/lib/bitbucket-cloud/bitbucket-cloud-contributors.ts
+++ b/src/lib/bitbucket-cloud/bitbucket-cloud-contributors.ts
@@ -9,7 +9,7 @@ import { Commits, Repo } from './types';
 import { fetchAllPages, isAnyCommitMoreThan90Days } from './utils';
 import { createImportFile, genericRepo, genericTarget } from '../common/utils';
 import * as debugLib from 'debug';
-const bitbucketCloudDefaultUrl = 'https://bitbucket.org';
+const bitbucketCloudDefaultUrl = 'https://api.bitbucket.org';
 const debug = debugLib('snyk:bitbucket-cloud-count');
 
 export const fetchBitbucketCloudContributors = async (
@@ -109,7 +109,7 @@ export const fetchBitbucketCloudContributorsForRepo = async (
   repo: Repo,
   contributorsMap: ContributorMap,
 ): Promise<void> => {
-  const fullUrl = `${bitbucketCloudDefaultUrl}/api/2.0/repositories/${repo.workspace.uuid}/${repo.slug}/commits?pagelen=100`;
+  const fullUrl = `${bitbucketCloudDefaultUrl}/2.0/repositories/${repo.workspace.uuid}/${repo.slug}/commits?pagelen=100`;
   try {
     debug(
       `Fetching single repo contributor from bitbucket-cloud. Worspace ${repo.workspace.uuid} - Repo ${repo.slug}\n`,
@@ -239,12 +239,12 @@ export const fetchBitbucketCloudReposForWorkspaces = async (
   // Filtering only the lowest role (member) to get the most repos (role is mandatory when using the is_private query)
   const fullUrlSet: string[] = !bitbucketCloudInfo.workspaces
     ? [
-        `${bitbucketCloudDefaultUrl}/api/2.0/repositories?q=is_private=true&role=member`,
-        `${bitbucketCloudDefaultUrl}/api/2.0/repositories?q=is_private=false&role=member`,
+        `${bitbucketCloudDefaultUrl}/2.0/repositories?q=is_private=true&role=member`,
+        `${bitbucketCloudDefaultUrl}/2.0/repositories?q=is_private=false&role=member`,
       ]
     : bitbucketCloudInfo.workspaces.map(
         (workspace) =>
-          `${bitbucketCloudDefaultUrl}/api/2.0/repositories/${workspace}?pagelen=100`,
+          `${bitbucketCloudDefaultUrl}/2.0/repositories/${workspace}?pagelen=100`,
       );
   try {
     for (let i = 0; i < fullUrlSet.length; i++) {

--- a/test/fixtures/bitbucket-cloud/repos-page1.json
+++ b/test/fixtures/bitbucket-cloud/repos-page1.json
@@ -124,5 +124,5 @@
             "description": ""
         }
     ],
-    "next": "https://bitbucket.org/api/2.0/repositories/snyk-main/page2"
+    "next": "https://api.bitbucket.org/2.0/repositories/snyk-main/page2"
 }

--- a/test/lib/bitbucket-cloud/bitbucket-cloud-contributors.test.ts
+++ b/test/lib/bitbucket-cloud/bitbucket-cloud-contributors.test.ts
@@ -15,19 +15,19 @@ const fixturesFolderPath =
   path.resolve(__dirname, '../..') + '/fixtures/bitbucket-cloud/';
 
 beforeEach(() => {
-  return nock('https://bitbucket.org')
+  return nock('https://api.bitbucket.org')
     .persist()
     .get(/.*/)
     .reply(200, (uri) => {
       console.log(uri);
       switch (uri) {
-        case '/api/2.0/repositories/snyk-test?pagelen=100':
+        case '/2.0/repositories/snyk-test?pagelen=100':
           return fs.readFileSync(fixturesFolderPath + 'snyk-test-repos.json');
-        case '/api/2.0/repositories/69a57492-684f-4c09-b8ba-17e03bd5e04a/testRepo1/commits?pagelen=100':
+        case '/2.0/repositories/69a57492-684f-4c09-b8ba-17e03bd5e04a/testRepo1/commits?pagelen=100':
           return fs.readFileSync(fixturesFolderPath + 'testRepo1-commits.json');
-        case '/api/2.0/repositories/snyk-main?pagelen=100':
+        case '/2.0/repositories/snyk-main?pagelen=100':
           return fs.readFileSync(fixturesFolderPath + 'repos-page1.json');
-        case '/api/2.0/repositories/snyk-main/page2':
+        case '/2.0/repositories/snyk-main/page2':
           return fs.readFileSync(fixturesFolderPath + 'repos-page2.json');
         default:
       }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Updates the bitbucket cloud to api tokens after [app password deprecation](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-enters-phase-2-of-app-password-deprecation).

### Notes for the reviewer

Straight replace app password for an api token in the commands. nothing else changes.
